### PR TITLE
Add proper filename parsing for `xx of xx covers`

### DIFF
--- a/src/py/utils/fnameparser.py
+++ b/src/py/utils/fnameparser.py
@@ -123,26 +123,29 @@ def __extract(name_s):
    
    # 6. remove all page counts, ie. "245p" or "50 pages"
    s = re.sub(r"(?i)\b[.,]?\s*\d+\s*(p|pg|pgs|pages)\b[.,]?", "", s)
+
+   # 7. remove anything following a similar pattern to "02 of 02 covers"
+   s = re.sub(r"(?i)(\d+\s*of\s*\d+\s*covers)", "", s)
    
-   # 7. if the name has things like "4 of 5", remove the " of 5" part
+   # 8. if the name has things like "4 of 5", remove the " of 5" part
    #    also, if the name has 3-6, remove the -6 part.  note that we'll
    #    try to handle the word "of" in a few common languages, like french/
    #    spanish (de), italian (di), german (von), dutch (van) or polish (z)
    s = re.sub(r"(?i)(?<=\d)(\s*(of|de|di|von|van|z)\s*#*\d+)", "", s)
    s = re.sub(r"(?<=\d)(-\d+)", "", s)
    
-   # 8. iff this is one of those comic books that replaces all spaces with
+   # 9. iff this is one of those comic books that replaces all spaces with
    #    dashes, then strip the dashes out.  otherwise leave them in (because
    #    they might be important, like minus signs or something.)
    if "-" in s and " " not in s:
       s = re.sub(r"(?<![-_# ])-", " ", s)
       
-   # 9. get an ordered list of issue number-like strings in the filename
+   # 10. get an ordered list of issue number-like strings in the filename
    #    for example:  3, #4, 5a, 6.00, 10.0b, .5, -1.0   
    #    also, remove numbers that look like years, EXCEPT on the "2000AD" series
    matches = __extract_numbers(s)
       
-   # 10. if there's multiple numbers in the filename, and it starts with 
+   # 11. if there's multiple numbers in the filename, and it starts with 
    #    something like "05. " or "12 - " we assuming these files are part of 
    #    a reading list, and we strip out that first part.
    pattern = r"^\s*\d+(\.\s+|\s*-\s*(?=\D))"
@@ -150,7 +153,7 @@ def __extract(name_s):
       s = re.sub(pattern, "", s, 1)
       matches = __extract_numbers(s)
       
-   # 11. if we parsed out some potential issue numbers, designate the LAST 
+   # 12. if we parsed out some potential issue numbers, designate the LAST 
    #    (rightmost) one as the actual issue number, and remove it from the name
    if len(matches) > 0: 
       issue_num_s = matches[-1].group(2)
@@ -165,7 +168,7 @@ def __extract(name_s):
       issue_num_s = ""
       series_s = s
 
-   # 12. contract repeating whitespace, and strip bad chars off the ends      
+   # 13. contract repeating whitespace, and strip bad chars off the ends      
    series_s = re.sub(r"\s{2,}", " ", series_s).strip(" ,-_") 
       
    return [series_s, issue_num_s, volume_year_s]


### PR DESCRIPTION
Previously `Batman 11 (02 of 03 covers)` would be parsed as:

```
Series Name: Batman 11
Number: 2
```

With this fix, the numbers related to the cover count will be ignored and it'll be properly parsed as:

```
Series Name: Batman
Number: 11
```